### PR TITLE
Fix for wrapping subtraction in difference calculations

### DIFF
--- a/image_segmentation.py
+++ b/image_segmentation.py
@@ -75,6 +75,10 @@ else:
         color = np.random.randint(0, 255, 3)
         img[img_rows[num]:, img_cols[num]:, :] = color
 
+# Create a version of the image data that is signed, so that subtraction will
+# not wrap around when computing differences.
+img_signed = img.astype(int)
+
 # Build the DQM and set biases according to pixel similarity
 print("\nPreparing DQM object...")
 rows, cols, _ = img.shape
@@ -89,7 +93,7 @@ for i in range(rows*cols):
         for case in range(num_segments):
             qb_rows.append(i*num_segments + case)
             qb_cols.append(j*num_segments + case)
-            qb_biases.append(weight(i, j, img))
+            qb_biases.append(weight(i, j, img_signed))
 quadratic_biases = (np.asarray(qb_rows), np.asarray(qb_cols), np.asarray(qb_biases))
 dqm = DiscreteQuadraticModel.from_numpy_vectors(case_starts, linear_biases, quadratic_biases)
 


### PR DESCRIPTION
Closes #10.  Image data are unsigned ints, which caused distance calculations to wrap around.  Resolved by creating a signed version of the image data to use for distance calculations.

Just in case anyone had been scratching their head about the previous results (notice the interior of the dino is not being segmented correctly):
![output_orig](https://user-images.githubusercontent.com/626029/140226338-b5d922b6-fc19-4489-b3ca-1e18a441caa3.png)

With this fix, the segmenting makes a lot more sense:
![output](https://user-images.githubusercontent.com/626029/140230812-e85468a5-0934-441c-9868-e148a0906b76.png)

